### PR TITLE
Adds savitar for 3MF plugins

### DIFF
--- a/Cura/control
+++ b/Cura/control
@@ -7,7 +7,7 @@ Build-Depends:
  python3-dev,
  python3-uranium, uranium-tools,
  qttools5-dev, qttools5-dev-tools,
- gettext,
+ gettext, python3-savitar,
  python3-pytest, pylint3,
 Standards-Version: 3.9.6
 Homepage: https://github.com/Ultimaker/Cura


### PR DESCRIPTION
3MF read/writing does not work if python3-savitar and libsavitar are not installed. This change adds python3-savitar (which also requires libsavitar) to dependences which makes it work again.