### PR TITLE
Cura: Environment hack for KDE

### DIFF
--- a/Cura/cura.envhack
+++ b/Cura/cura.envhack
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export XDG_CONFIG_DIRS=/etc/xdg
+unset XDG_SESSION_DESKTOP
+unset XDG_CURRENT_DESKTOP
+unset KDE_FULL_SESSION
+unset KDE_SESSION_UID
+unset KDE_SESSION_VERSION
+
+cura.real "$@"

--- a/Cura/cura.install
+++ b/Cura/cura.install
@@ -1,4 +1,4 @@
-/usr/bin/cura
+/usr/bin/
 /usr/lib/cura/plugins/3MFReader
 /usr/lib/cura/plugins/3MFWriter
 /usr/lib/cura/plugins/AMFReader

--- a/Cura/rules
+++ b/Cura/rules
@@ -28,6 +28,12 @@ override_dh_auto_configure:
 	                  -DCURA_VERSION="$(DEB_PACKAGE_VERSION)-PPA" \
 	                  -DCURA_SDK_VERSION=6.0.0
 
+override_dh_auto_install:
+	dh_auto_install
+	# Hacking Cura with some environment hacks for KDE
+	mv debian/tmp/usr/bin/cura debian/tmp/usr/bin/cura.real
+	cp -fv debian/cura.envhack debian/tmp/usr/bin/cura
+
 override_dh_installmime:
 	cp -fv cura.sharedmimeinfo debian/cura.sharedmimeinfo
 	dh_installmime -O--buildsystem=cmake -O--parallel


### PR DESCRIPTION
Workaround for display errors, like missing margins, etc.
Kicking out some environment variables did the trick.